### PR TITLE
chore: Register remote pytest marker in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,8 @@ lint.ignore = ["F401"]
 
 [tool.deptry.package_module_name_map]
 sparqlwrapper = "SPARQLWrapper"
+
+[tool.pytest.ini_options]
+markers = [
+	"remote: Mark tests that connect to a remote service",
+]


### PR DESCRIPTION
Tests targeting an actual remote endpoint should be marked with a 'remote' marker. Custom markers should be registered, else pytest emits a warning.