### PR TITLE
feat: Use conftest.py for global fixture definitions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Conftest.py for RDFProxy."""
+
+import pytest
+
+from SPARQLWrapper import JSON, SPARQLWrapper
+
+
+def _sparql_wrapper_fixture_factory(endpoint: str, return_format=JSON):
+    """Return a SPARQLWrapper fixture with the endpoint and return format_set."""
+
+    @pytest.fixture
+    def sparql_wrapper():
+        sparql = SPARQLWrapper(endpoint)
+        sparql.setReturnFormat(return_format)
+        return sparql
+
+    return sparql_wrapper
+
+
+wikidata_wrapper = _sparql_wrapper_fixture_factory(
+    "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
+)


### PR DESCRIPTION
Importing fixtures is a pytest antipattern and causes Ruff to flag F811. See https://github.com/astral-sh/ruff/issues/4046. Defining fixtures globally in conftest.py is the idiomatic way to remedy the problem.