### PR TITLE
feat: Check for JSON result format to get_bindings_from_query_result

### DIFF
--- a/rdfproxy/utils/utils.py
+++ b/rdfproxy/utils/utils.py
@@ -10,6 +10,12 @@ from toolz import valmap
 
 def get_bindings_from_query_result(query_result: QueryResult) -> Iterator[dict]:
     """Extract just the bindings from a SPARQLWrapper.QueryResult."""
+    if (result_format := query_result.requestedFormat) != "json":
+        raise Exception(
+            "Only QueryResult objects with JSON format are currently supported. "
+            f"Received object with requestedFormat '{result_format}'."
+        )
+
     query_json = cast(Mapping, query_result.convert())
     bindings = map(
         lambda binding: valmap(lambda v: v["value"], binding),


### PR DESCRIPTION
The default return format for SPARQLWrapper is XML, yet JSON is required for `get_bindings_from_query_result`. Since the format option cannot be set from an already retrieved QueryResult object and the function depends on JSON results, raise an error if the set result format is not JSON.