### PR TITLE
test: Implement basic tests

### DIFF
--- a/tests/data/init_model_from_kwargs_parameters.py
+++ b/tests/data/init_model_from_kwargs_parameters.py
@@ -1,0 +1,23 @@
+"""Model and kwargs data mappings for testing."""
+
+from rdfproxy import instantiate_model_from_kwargs
+from tests.data.models import ComplexModel, NestedModel, SimpleModel
+
+
+init_model_from_kwargs_parameters = [
+    (SimpleModel, [{"x": 1}, {"x": 1, "y": 2}]),
+    (
+        NestedModel,
+        [
+            {"x": 1, "a": "a value"},
+            {"x": 1, "y": 2, "a": "a value"},
+        ],
+    ),
+    (
+        ComplexModel,
+        [
+            {"p": "p value", "a": "a value", "x": 1},
+            {"p": "p value", "a": "a value", "x": 1, "y": 2},
+        ],
+    ),
+]

--- a/tests/data/models.py
+++ b/tests/data/models.py
@@ -1,0 +1,18 @@
+"""Pydantic model definitions for testing."""
+
+from pydantic import BaseModel
+
+
+class SimpleModel(BaseModel):
+    x: int
+    y: int = 3
+
+
+class NestedModel(BaseModel):
+    a: str
+    b: SimpleModel
+
+
+class ComplexModel(BaseModel):
+    p: str
+    q: NestedModel

--- a/tests/test_get_bindings_from_query_result.py
+++ b/tests/test_get_bindings_from_query_result.py
@@ -1,0 +1,33 @@
+"""Pytest entry point for rdfproxy.get_bindings_query_result tests."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from SPARQLWrapper import JSON, QueryResult, SPARQLWrapper
+from rdfproxy import get_bindings_from_query_result
+
+
+@pytest.mark.remote
+def test_get_bindings_from_query_result_basic(wikidata_wrapper):
+    """Simple base test for get_bindings_from_query_result.
+
+    Run a VALUES query and check keys and values of the bindings dict.
+    """
+    query = """
+    select ?x ?y ?a ?p
+    where {
+        values (?x ?y ?a ?p) {
+            (1 2 "a value" "p value")
+        }
+    }
+    """
+
+    wikidata_wrapper.setQuery(query)
+    result: QueryResult = wikidata_wrapper.query()
+
+    bindings: Iterator[dict] = get_bindings_from_query_result(result)
+    binding = next(bindings)
+
+    assert all(var in binding.keys() for var in ["x", "y", "a", "p"])
+    assert all(value in binding.values() for value in ["1", "2", "a value", "p value"])

--- a/tests/test_instantiate_model_from_kwargs.py
+++ b/tests/test_instantiate_model_from_kwargs.py
@@ -1,0 +1,16 @@
+"""Pytest entry point for rdfproxy.instantiate_model_from_kwargs tests."""
+
+import pytest
+
+from rdfproxy import instantiate_model_from_kwargs
+from tests.data.init_model_from_kwargs_parameters import (
+    init_model_from_kwargs_parameters,
+)
+
+
+@pytest.mark.parametrize(("model", "kwargs"), init_model_from_kwargs_parameters)
+def test_init_model_from_kwargs(model, kwargs):
+    """Check if the init_model_from_kwargs constructor successfully inits a model based on kwargs."""
+    for _kwargs in kwargs:
+        model_instance = instantiate_model_from_kwargs(model, **_kwargs)
+        assert isinstance(model_instance, model)

--- a/tests/test_sparql_model_adapter.py
+++ b/tests/test_sparql_model_adapter.py
@@ -1,0 +1,24 @@
+"""Pytest entry point for rdfproxy.SPARQLModelAdapter tests."""
+
+import pytest
+
+from rdfproxy import SPARQLModelAdapter
+from tests.data.models import ComplexModel
+
+
+@pytest.mark.remote
+def test_sparql_model_adapter_basic(wikidata_wrapper):
+    """Simple base test for SPARQLModelAdapter."""
+    query = """
+    select ?x ?y ?a ?p
+    where {
+        values (?x ?y ?a ?p) {
+            (1 2 "a value" "p value")
+        }
+    }
+    """
+    wikidata_wrapper.setQuery(query)
+    adapter = SPARQLModelAdapter(sparql_wrapper=wikidata_wrapper)
+    model, *_ = adapter(query=query, model_constructor=ComplexModel)
+
+    assert isinstance(model, ComplexModel)


### PR DESCRIPTION
Implement basic tests for
- SPARQLModelAdapter,
- get_bindings_from_query_result and
- instantiate_model_from_kwargs.

These basic tests merely aim to initialize the testing suite and are relatively primitive: E.g. just the happy path is targeted and the tests are rather verbose.

closes: #17