### PR TITLE
Lupl/port 311 project

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/poetry.lock
+++ b/poetry.lock
@@ -529,5 +529,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "ff459a3dae51d5ea151b297060991fc51184905246f7da160b668c33b26058e6"
+python-versions = "^3.11"
+content-hash = "8be538349f9de2707e8a3b055ac6c891dd4617b1282e0d4cd72b2652ceb9f8a1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 sparqlwrapper = "^2.0.0"
 toolz = "^0.12.1"
 pydantic = "^2.8.2"


### PR DESCRIPTION
Set version to 3.11 in `pyproject.toml` and update lock.

Also update test matrix to run tests for 3.11.

Concerns #25.