### PR TITLE
Lupl/port 311 code

### DIFF
--- a/rdfproxy/adapter.py
+++ b/rdfproxy/adapter.py
@@ -5,7 +5,6 @@ from typing import cast
 
 from SPARQLWrapper import JSON, QueryResult, SPARQLWrapper
 from pydantic import BaseModel
-
 from rdfproxy.utils._types import _TModelConstructorCallable, _TModelInstance
 from rdfproxy.utils.utils import (
     get_bindings_from_query_result,

--- a/rdfproxy/utils/_types.py
+++ b/rdfproxy/utils/_types.py
@@ -1,7 +1,7 @@
 """Type definitions for rdfproxy."""
 
 from collections.abc import Iterable
-from typing import Annotated, Protocol, TypeVar, runtime_checkable
+from typing import Protocol, TypeVar, runtime_checkable
 
 from SPARQLWrapper import QueryResult
 from pydantic import BaseModel

--- a/rdfproxy/utils/_types.py
+++ b/rdfproxy/utils/_types.py
@@ -11,7 +11,7 @@ _TModelInstance = TypeVar("_TModelInstance", bound=BaseModel)
 
 
 @runtime_checkable
-class _TModelConstructorCallable[ModelType: BaseModel](Protocol):
+class _TModelConstructorCallable(Protocol[_TModelInstance]):
     """Callback protocol for model constructor callables."""
 
-    def __call__(self, query_result: QueryResult) -> Iterable[ModelType]: ...
+    def __call__(self, query_result: QueryResult) -> Iterable[_TModelInstance]: ...

--- a/rdfproxy/utils/utils.py
+++ b/rdfproxy/utils/utils.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from SPARQLWrapper import QueryResult
 from pydantic import BaseModel
+from rdfproxy.utils._types import _TModelInstance
 from toolz import valmap
 
 

--- a/rdfproxy/utils/utils.py
+++ b/rdfproxy/utils/utils.py
@@ -26,9 +26,9 @@ def get_bindings_from_query_result(query_result: QueryResult) -> Iterator[dict]:
     return bindings
 
 
-def instantiate_model_from_kwargs[ModelType: BaseModel](
-    model: type[ModelType], **kwargs
-) -> ModelType:
+def instantiate_model_from_kwargs(
+    model: type[_TModelInstance], **kwargs
+) -> _TModelInstance:
     """Instantiate a (potentially nested) model from (flat) kwargs.
 
     Example:
@@ -52,7 +52,7 @@ def instantiate_model_from_kwargs[ModelType: BaseModel](
     print(model)  # p='p value' q=NestedModel(a='a value', b=SimpleModel(x=1, y=2))
     """
 
-    def _get_bindings(model: type[ModelType], **kwargs) -> dict:
+    def _get_bindings(model: type[_TModelInstance], **kwargs) -> dict:
         """Get the bindings needed for model instantation.
 
         The function traverses model.model_fields


### PR DESCRIPTION
Make code adaptions to support Python 3.11.

Mainly, this means replacing PEP 659 parameter syntax. 
This PR also includes minor fixes (removal of unsused imports etc.)

Closes #25