### PR TITLE
ci: Remove Ruff F401 exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,6 @@ hypothesis = "^6.108.4"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-
-[tool.ruff]
-lint.ignore = ["F401"]
-
 [tool.deptry.package_module_name_map]
 sparqlwrapper = "SPARQLWrapper"
 


### PR DESCRIPTION
F401 is useful check and should be included in Ruff linting.

Closes #34.