### PR TITLE
fix(tests): Target DBPedia instead of Wikidata for remote tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,4 @@ def _sparql_wrapper_fixture_factory(endpoint: str, return_format=JSON):
     return sparql_wrapper
 
 
-wikidata_wrapper = _sparql_wrapper_fixture_factory(
-    "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
-)
+wikidata_wrapper = _sparql_wrapper_fixture_factory("https://dbpedia.org/sparql")

--- a/tests/test_sparql_model_adapter.py
+++ b/tests/test_sparql_model_adapter.py
@@ -22,7 +22,7 @@ def test_sparql_model_adapter_basic():
     }
     """
     adapter = SPARQLModelAdapter(
-        target="https://query.wikidata.org/bigdata/namespace/wdq/sparql",
+        target="https://dbpedia.org/sparql",
         query=query,
         model=ComplexModel,
     )
@@ -44,7 +44,7 @@ def test_sparql_model_adapter_grouping_basic():
     """
 
     adapter = SPARQLModelAdapter(
-        target="https://query.wikidata.org/bigdata/namespace/wdq/sparql",
+        target="https://dbpedia.org/sparql",
         query=query,
         model=ComplexModel,
     )
@@ -77,7 +77,7 @@ def test_sparql_model_adapter_grouping_basic_fail(var):
     """
 
     adapter = SPARQLModelAdapter(
-        target="https://query.wikidata.org/bigdata/namespace/wdq/sparql",
+        target="https://dbpedia.org/sparql",
         query=query,
         model=ComplexModel,
     )


### PR DESCRIPTION
As of recently, Wikidata apparently rejects the default SPARQLWrapper user agent, so remote tests targeting Wikidata fail unless the agent parameter is explicitly set. See https://github.com/RDFLib/sparqlwrapper/issues/237.

All affected remote tests use toy VALUES queries, so targeting DBPedia (or any other triplestore) resolves the issue for now.