### PR TITLE
chore(test): Swap deprecated model.dict for model.model_dump

### DIFF
--- a/tests/test_instantiate_model_from_kwargs.py
+++ b/tests/test_instantiate_model_from_kwargs.py
@@ -23,4 +23,4 @@ def test_explicit_sparql_binding_allocation():
 
     model = instantiate_model_from_kwargs(Person, **bindings)
 
-    assert expected == model.dict()
+    assert expected == model.model_dump()


### PR DESCRIPTION
model.dict is deprecated, model.model_dump should be used instead, else a warning is emitted.
See https://docs.pydantic.dev/latest/concepts/serialization/#modelmodel_dump.

Closes: #70.