### PR TITLE
chore: Declutter public library interface

### DIFF
--- a/rdfproxy/__init__.py
+++ b/rdfproxy/__init__.py
@@ -1,6 +1,3 @@
 from rdfproxy.adapter import SPARQLModelAdapter  # noqa: F401
-from rdfproxy.utils._types import _TModelConstructorCallable, _TModelInstance  # noqa: F401
-from rdfproxy.utils.utils import (
-    get_bindings_from_query_result,  # noqa: F401
-    instantiate_model_from_kwargs,  # noqa: F401
-)
+from rdfproxy.utils._types import SPARQLBinding  # noqa: F401
+from rdfproxy.utils.models import Page  # noqa: F401

--- a/tests/test_get_bindings_from_query_result.py
+++ b/tests/test_get_bindings_from_query_result.py
@@ -4,7 +4,7 @@ from collections.abc import Iterator
 
 from SPARQLWrapper import QueryResult
 import pytest
-from rdfproxy import get_bindings_from_query_result
+from rdfproxy.utils.utils import get_bindings_from_query_result
 
 
 @pytest.mark.remote

--- a/tests/test_instantiate_model_from_kwargs.py
+++ b/tests/test_instantiate_model_from_kwargs.py
@@ -1,8 +1,7 @@
 """Pytest entry point for rdfproxy.instantiate_model_from_kwargs tests."""
 
 import pytest
-
-from rdfproxy import instantiate_model_from_kwargs
+from rdfproxy.utils.utils import instantiate_model_from_kwargs
 from tests.data.init_model_from_kwargs_parameters import (
     init_model_from_kwargs_parameters,
 )


### PR DESCRIPTION
The public library interface currently only needs to expose SPARQLModelAdapter, SPARQLBinding and Page.