### PR TITLE
refactor: implement inject_subquery with re.search and str slicing

### DIFF
--- a/rdfproxy/utils/_exceptions.py
+++ b/rdfproxy/utils/_exceptions.py
@@ -7,3 +7,7 @@ class MissingModelConfigException(Exception):
 
 class UnboundGroupingKeyException(Exception):
     """Exception for indicating that no SPARQL binding corresponds to the requested grouping key."""
+
+
+class QueryConstructionException(Exception):
+    """Exception for indicating failed SPARQL query construction."""


### PR DESCRIPTION
The regex with an absolute anchor + negated char set is more precise than the original version. Also, indentation is completely unnecessary, a potential source of bugs and clutters up the implementation.