### PR TITLE
fix(logging): use % format specifier for logging

### DIFF
--- a/rdfproxy/adapter.py
+++ b/rdfproxy/adapter.py
@@ -46,16 +46,16 @@ class SPARQLModelAdapter(Generic[_TModelInstance]):
         self.sparql_strategy = sparql_strategy(self._target)
 
         logger.info("Initialized SPARQLModelAdapter.")
-        logger.debug(f"Endpoint: {self._target}")
-        logger.debug(f"Model: {self._model}")
-        logger.debug(f"Query: \n{self._query}")
+        logger.debug("Endpoint: %s", self._target)
+        logger.debug("Model: %s", self._model)
+        logger.debug("Query: \n%s", self._query)
 
     def query(
         self, query_parameters: QueryParameters = QueryParameters()
     ) -> Page[_TModelInstance]:
         """Run a query against an endpoint and return a Page model object."""
         logger.info(
-            f"Running SPARQLModelAdapter.query against endpoint '{self._target}'"
+            "Running SPARQLModelAdapter.query against endpoint '%'", self._target
         )
 
         query_constructor = QueryConstructor(
@@ -67,13 +67,13 @@ class SPARQLModelAdapter(Generic[_TModelInstance]):
         count_query = query_constructor.get_count_query()
         items_query = query_constructor.get_items_query()
 
-        logger.debug(f"Running items query: \n{items_query}")
+        logger.debug("Running items query: \n%s", items_query)
 
         items_query_bindings: Iterator[dict] = self.sparql_strategy.query(items_query)
         mapper = ModelBindingsMapper(self._model, *items_query_bindings)
         items: list[_TModelInstance] = mapper.get_models()
 
-        logger.debug(f"Running count query: \n{count_query}")
+        logger.debug("Running count query: \n%s", count_query)
 
         count_query_bindings: Iterator[dict] = self.sparql_strategy.query(count_query)
         total: int = int(next(count_query_bindings)["cnt"])


### PR DESCRIPTION
As pointed out by @b1rger in https://github.com/acdh-oeaw/rdfproxy/pull/188, % format specifiers should be used instead of f-strings in log messages.

Closes #196.