### PR TITLE
feat: implement query checking

### DIFF
--- a/rdfproxy/adapter.py
+++ b/rdfproxy/adapter.py
@@ -5,7 +5,7 @@ import logging
 import math
 from typing import Generic
 
-from rdfproxy.constructor import QueryConstructor
+from rdfproxy.constructor import _QueryConstructor
 from rdfproxy.mapper import _ModelBindingsMapper
 from rdfproxy.sparql_strategies import HttpxStrategy, SPARQLStrategy
 from rdfproxy.utils._types import _TModelInstance
@@ -59,7 +59,7 @@ class SPARQLModelAdapter(Generic[_TModelInstance]):
             "Running SPARQLModelAdapter.query against endpoint '%'", self._target
         )
 
-        query_constructor = QueryConstructor(
+        query_constructor = _QueryConstructor(
             query=self._query,
             query_parameters=query_parameters,
             model=self._model,

--- a/rdfproxy/adapter.py
+++ b/rdfproxy/adapter.py
@@ -9,6 +9,7 @@ from rdfproxy.constructor import QueryConstructor
 from rdfproxy.mapper import _ModelBindingsMapper
 from rdfproxy.sparql_strategies import HttpxStrategy, SPARQLStrategy
 from rdfproxy.utils._types import _TModelInstance
+from rdfproxy.utils.checkers.query_checker import check_query
 from rdfproxy.utils.models import Page, QueryParameters
 
 
@@ -40,7 +41,7 @@ class SPARQLModelAdapter(Generic[_TModelInstance]):
         sparql_strategy: type[SPARQLStrategy] = HttpxStrategy,
     ) -> None:
         self._target = target
-        self._query = query
+        self._query = check_query(query)
         self._model = model
 
         self.sparql_strategy = sparql_strategy(self._target)

--- a/rdfproxy/constructor.py
+++ b/rdfproxy/constructor.py
@@ -1,5 +1,4 @@
 from rdfproxy.utils._types import _TModelInstance
-from rdfproxy.utils.checkers.query_checker import check_query
 from rdfproxy.utils.models import QueryParameters
 from rdfproxy.utils.sparql_utils import (
     add_solution_modifier,
@@ -15,7 +14,7 @@ from rdfproxy.utils.utils import (
 )
 
 
-class QueryConstructor:
+class _QueryConstructor:
     """The class encapsulates dynamic SPARQL query modification logic
     for implementing purely SPARQL-based, deterministic pagination.
 

--- a/rdfproxy/constructor.py
+++ b/rdfproxy/constructor.py
@@ -1,4 +1,5 @@
 from rdfproxy.utils._types import _TModelInstance
+from rdfproxy.utils.checkers.query_checker import check_query
 from rdfproxy.utils.models import QueryParameters
 from rdfproxy.utils.sparql_utils import (
     add_solution_modifier,

--- a/rdfproxy/utils/_exceptions.py
+++ b/rdfproxy/utils/_exceptions.py
@@ -11,3 +11,18 @@ class InvalidGroupingKeyException(Exception):
 
 class QueryConstructionException(Exception):
     """Exception for indicating failed SPARQL query construction."""
+
+
+class UnsupportedQueryException(Exception):
+    """Exception for indicating that a given SPARQL query is not supported."""
+
+
+class QueryParseException(Exception):
+    """Exception for indicating that a given SPARQL query raised a parse error.
+
+    This exception is intended to wrap and re-raise all exceptions
+    raised from parsing a SPARQL query with RDFLib's parseQuery function.
+
+    parseQuery raises a pyparsing.exceptions.ParseException,
+    which would require to introduce pyparsing as a dependency just for testing.
+    """

--- a/rdfproxy/utils/checkers/query_checker.py
+++ b/rdfproxy/utils/checkers/query_checker.py
@@ -1,0 +1,57 @@
+"""Functionality for performing checks on SPARQL queries."""
+
+import logging
+
+from rdfproxy.utils._exceptions import UnsupportedQueryException
+from rdfproxy.utils._types import ParsedSPARQL, _TQuery
+from rdfproxy.utils.utils import compose_left
+
+
+logger = logging.getLogger(__name__)
+
+
+def _check_select_query(parsed_sparql: ParsedSPARQL) -> ParsedSPARQL:
+    """Check if a SPARQL query is a SELECT query.
+
+    This is meant to run as a component in check_query.
+    """
+    logger.debug("Running SELECT query check.")
+
+    if parsed_sparql.parse_object.name != "SelectQuery":
+        raise UnsupportedQueryException("Only SELECT queries are applicable.")
+    return parsed_sparql
+
+
+def _check_solution_modifiers(parsed_sparql: ParsedSPARQL) -> ParsedSPARQL:
+    """Check if a SPARQL query has a solution modifier.
+
+    This is meant to run as a component in check_query.
+    """
+    logger.debug("Running solution modifier check.")
+
+    def _has_modifier():
+        for mod_name in ["limitoffset", "groupby", "having", "orderby"]:
+            if (mod := getattr(parsed_sparql.parse_object, mod_name)) is not None:
+                return mod
+        return False
+
+    if mod := _has_modifier():
+        logger.critical("Detected solution modifier '%s' in outer query.", mod)
+        raise UnsupportedQueryException(
+            "Solution modifiers for top-level queries are currently not supported."
+        )
+
+    return parsed_sparql
+
+
+def check_query(query: _TQuery) -> _TQuery:
+    """Check a SPARQL query by running a compose pipeline of checks."""
+    logger.debug("Running query check pipeline on '%s'", query)
+    parsed_sparql = ParsedSPARQL(query=query)
+
+    result: ParsedSPARQL = compose_left(
+        _check_select_query,
+        _check_solution_modifiers,
+    )(parsed_sparql)
+
+    return result.data

--- a/tests/tests_adapter/test_adapter_check_query_sad_path.py
+++ b/tests/tests_adapter/test_adapter_check_query_sad_path.py
@@ -1,0 +1,26 @@
+"""Sad path tests for SPARQLModelAdapter with invalid queries"""
+
+from pydantic import BaseModel
+import pytest
+from rdfproxy.adapter import SPARQLModelAdapter
+from rdfproxy.utils._exceptions import QueryParseException, UnsupportedQueryException
+from tests.unit.tests_checkers.test_query_checker import (
+    fail_queries_parse_exception,
+    fail_queries_unsupported,
+)
+
+
+class Dummy(BaseModel):
+    pass
+
+
+@pytest.mark.parametrize("query", fail_queries_parse_exception)
+def test_adapter_parse_exception(query):
+    with pytest.raises(QueryParseException):
+        SPARQLModelAdapter(target="dummy.target", model=Dummy, query=query)
+
+
+@pytest.mark.parametrize("query", fail_queries_unsupported)
+def test_adapter_unsupported_exception(query):
+    with pytest.raises(UnsupportedQueryException):
+        SPARQLModelAdapter(target="dummy.target", model=Dummy, query=query)

--- a/tests/tests_constructor/test_query_constructor_items_query.py
+++ b/tests/tests_constructor/test_query_constructor_items_query.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 import pytest
 
 from pydantic import BaseModel
-from rdfproxy.constructor import QueryConstructor
+from rdfproxy.constructor import _QueryConstructor
 from rdfproxy.utils._types import ConfigDict
 from rdfproxy.utils.models import QueryParameters
 
@@ -97,7 +97,7 @@ parameters = [
 
 @pytest.mark.parametrize(["query", "query_parameters", "model", "expected"], parameters)
 def test_query_constructor_items_query(query, query_parameters, model, expected):
-    constructor = QueryConstructor(
+    constructor = _QueryConstructor(
         query=query, query_parameters=query_parameters, model=model
     )
 

--- a/tests/unit/tests_checkers/test_query_checker.py
+++ b/tests/unit/tests_checkers/test_query_checker.py
@@ -1,0 +1,45 @@
+"""Unit test for rdfproxy.utils.checkers.query_checker."""
+
+import pytest
+from rdfproxy.utils._exceptions import QueryParseException, UnsupportedQueryException
+from rdfproxy.utils.checkers.query_checker import check_query
+
+
+fail_queries_parse_exception: list[str] = [
+    "select * where {?s ?p ?o ",
+    "select * where {?s ?p}",
+    "select ? where {?s ?p ?o}",
+    "select * where {?s ?p ?o } limit",
+    """
+    PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+    select * where {?s ?p ?o } limit
+    """,
+]
+fail_queries_unsupported: list[str] = [
+    # query types
+    "ask where {?s ?p ?o}",
+    """
+    PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+    ask where {?s ?p ?o}
+    """,
+    "construct {?s ?p ?o} where {?s ?p ?o}",
+    "describe ?s where {?s ?p ?o}",
+    # solution modifiers
+    "select * where {?s ?p ?o .} limit 10",
+    "select * where {?s ?p ?o .} offset 1",
+    "select * where {?s ?p ?o .} limit 2 offset 1",
+    "select ?s where {?s ?p ?o .} group by ?s",
+    "select ?s where {?s ?p ?o .} group by ?s having (?o > 1)",
+]
+
+
+@pytest.mark.parametrize("query", fail_queries_parse_exception)
+def test_check_query_parse_exception(query):
+    with pytest.raises(QueryParseException):
+        check_query(query)
+
+
+@pytest.mark.parametrize("query", fail_queries_unsupported)
+def test_check_query_unsupported(query):
+    with pytest.raises(UnsupportedQueryException):
+        check_query(query)


### PR DESCRIPTION
The change introduces a `check_query` callable which runs an extensible compose pipeline of query checkers against a given SPARQL query. The `check_query` function runs in `SPARQLModelAdapter` to enable fast failures on inapplicable queries.

Closes #116.