### PR TITLE
fix: reference private _QueryConstructor correctly in mkdocs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,12 +1,10 @@
 name: docs
 on:
   push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:
-  build:
-
+  docs:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +21,9 @@ jobs:
       - name: Install dependencies
         run: poetry install --only dev
 
-      - name: Validate MkDocs build
+      - name: Build MkDocs
         run: poetry run mkdocs build --strict
 
       - name: Deploy MkDocs
+        if: github.ref == 'refs/heads/main'
         run: poetry run mkdocs gh-deploy --force

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,9 +1,9 @@
-This part of the documentation provides automatically generated information about public symbols.
+This part of the documentation provides automatically generated information about RDFProxy symbols.
 
 ---
 ::: rdfproxy.adapter.SPARQLModelAdapter
 ---
-::: rdfproxy.constructor.QueryConstructor
+::: rdfproxy.constructor._QueryConstructor
 ---
 ::: rdfproxy.mapper._ModelBindingsMapper
 ---


### PR DESCRIPTION
The MkDocs workflow failed because I made `_QueryConstructor` private and didn't update the mkdocs reference generator.

This PR fixes the issue and also adapts the workflow to build on push to any branch, but deploy only on push to main. 