### PR TITLE
Lupl/fix all undef aggregates

### DIFF
--- a/rdfproxy/sparqlwrapper.py
+++ b/rdfproxy/sparqlwrapper.py
@@ -12,17 +12,23 @@ class SPARQLWrapper:
     def query(self, query: str) -> Iterator[dict[str, str]]:
         """Run a SPARQL query against endpoint and return an Iterator of flat result mappings."""
         result: httpx.Response = self._httpx_run_sparql_query(query)
-        return self._get_bindings_from_bindings_dict(result.json())
+        return self._get_bindings_from_json_response(result.json())
 
     @staticmethod
-    def _get_bindings_from_bindings_dict(bindings_dict: dict) -> Iterator[dict]:
-        bindings = map(
-            lambda binding: {k: v["value"] for k, v in binding.items()},
-            bindings_dict["results"]["bindings"],
+    def _get_bindings_from_json_response(json_response: dict) -> Iterator[dict]:
+        """Get flat dicts from a SPARQL SELECT JSON response."""
+        variables = json_response["head"]["vars"]
+        response_bindings = json_response["results"]["bindings"]
+
+        bindings = (
+            {var: binding.get(var, {}).get("value") for var in variables}
+            for binding in response_bindings
         )
+
         return bindings
 
     def _httpx_run_sparql_query(self, query: str) -> httpx.Response:
+        """Run a query against endpoint using httpx.post."""
         data = {"output": "json", "query": query}
         headers = {
             "Accept": "application/sparql-results+json",


### PR DESCRIPTION
The case where all bindings in a SPARQL result set are UNDEF and that
binding is used in an aggregation field in an RDFProxy-compliant model
caused a KeyError on dataframe lookup, because UNDEF bindings are
excluded from the SPARQL response (see
https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/#select-bindings)
and for the dataframe to have the column for a binding, at least one
entry for that binding must be in the response.

The change fixes this issue by complementing UNDEF bindings in the
SPARQL response processing by resolving the response JSON against the
"vars" entry in the response header. I.e. every request binding will
be in the processed response dict, even if it is UNDEF and therefore
excluded from the JSON response.

Closes https://github.com/acdh-oeaw/rdfproxy/issues/207.
