### PR TITLE
Prototype/ordering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-added-large-files
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.9.6
+  hooks:
+    # Run the linter.
+    - id: ruff
+    # Run the formatter.
+    - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RDFProxy
 
-![tests](https://github.com/acdh-oeaw/rdfproxy/actions/workflows/tests.yaml/badge.svg)
+![tests](https://github.com/acdh-oeaw/rdfproxy/actions/workflows/tests.yml/badge.svg)
 [![coverage](https://coveralls.io/repos/github/acdh-oeaw/rdfproxy/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/acdh-oeaw/rdfproxy?branch=main&kill_cache=1)
 [![docs](https://github.com/acdh-oeaw/rdfproxy/actions/workflows/deploy-docs.yml/badge.svg)](https://acdh-oeaw.github.io/rdfproxy/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)

--- a/examples/full_static_fastapi_example.py
+++ b/examples/full_static_fastapi_example.py
@@ -4,7 +4,7 @@ import logging
 from typing import Annotated
 
 from fastapi import FastAPI, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from rdfproxy import (
     ConfigDict,
     Page,
@@ -45,8 +45,6 @@ class Author(BaseModel):
     surname: Annotated[str, SPARQLBinding("authorName")]
     works: list[Work]
     education: Annotated[list[str], SPARQLBinding("educatedAt")]
-
-    workName: str = Field(exclude=True, description="Excluded field for ordering.")
 
 
 adapter = SPARQLModelAdapter(

--- a/examples/wikidata_grouped_person_fastapi_example.py
+++ b/examples/wikidata_grouped_person_fastapi_example.py
@@ -46,5 +46,7 @@ app = FastAPI()
 
 
 @app.get("/")
-def base_route(query_parameters: Annotated[QueryParameters, Query()]) -> Page[Person]:
+def base_route(
+    query_parameters: Annotated[QueryParameters[Person], Query()],
+) -> Page[Person]:
     return adapter.query(query_parameters)

--- a/examples/wikidata_ungrouped_person_fastapi_example.py
+++ b/examples/wikidata_ungrouped_person_fastapi_example.py
@@ -3,7 +3,7 @@
 from typing import Annotated
 
 from fastapi import FastAPI, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from rdfproxy import Page, QueryParameters, SPARQLBinding, SPARQLModelAdapter
 
 
@@ -26,6 +26,8 @@ class Person(BaseModel):
     name: str
     work: Work
 
+    work_name: Annotated[str, SPARQLBinding("title")] = Field(exclude=True)
+
 
 adapter = SPARQLModelAdapter(
     target="https://query.wikidata.org/bigdata/namespace/wdq/sparql",
@@ -38,5 +40,7 @@ app = FastAPI()
 
 
 @app.get("/")
-def base_route(query_parameters: Annotated[QueryParameters, Query()]) -> Page[Person]:
+def base_route(
+    query_parameters: Annotated[QueryParameters[Person], Query()],
+) -> Page[Person]:
     return adapter.query(query_parameters)

--- a/examples/wikidata_ungrouped_person_fastapi_example.py
+++ b/examples/wikidata_ungrouped_person_fastapi_example.py
@@ -3,7 +3,7 @@
 from typing import Annotated
 
 from fastapi import FastAPI, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from rdfproxy import Page, QueryParameters, SPARQLBinding, SPARQLModelAdapter
 
 
@@ -25,8 +25,6 @@ class Work(BaseModel):
 class Person(BaseModel):
     name: str
     work: Work
-
-    work_name: Annotated[str, SPARQLBinding("title")] = Field(exclude=True)
 
 
 adapter = SPARQLModelAdapter(

--- a/rdfproxy/constructor.py
+++ b/rdfproxy/constructor.py
@@ -9,6 +9,7 @@ from rdfproxy.utils.sparql_utils import (
 )
 from rdfproxy.utils.utils import (
     FieldsBindingsMap,
+    NamespacedFieldBindingsMap,
     QueryConstructorComponent as component,
     compose_left,
 )
@@ -33,10 +34,13 @@ class _QueryConstructor:
         self.model = model
 
         self.bindings_map = FieldsBindingsMap(model)
+        self.namespaced_bindings_map = NamespacedFieldBindingsMap(model)
         self.group_by: str | None = self.bindings_map.get(
             model.model_config.get("group_by")
         )
-        self.order_by: str | None = self.bindings_map.get(query_parameters.order_by)
+        self.order_by: str | None = self.namespaced_bindings_map.get(
+            query_parameters.order_by
+        )
 
         print("DEBUG: ", self.order_by)
 

--- a/rdfproxy/utils/mapper_utils.py
+++ b/rdfproxy/utils/mapper_utils.py
@@ -15,6 +15,10 @@ def _is_list_type(obj: type | None) -> bool:
     return _is_type(obj, list)
 
 
+def _is_scalar_type(t) -> bool:
+    return (not _is_list_type(t)) and (not issubclass(t, BaseModel))
+
+
 def _is_list_basemodel_type(obj: type | None) -> bool:
     """Check if a type is list[pydantic.BaseModel]."""
     return (get_origin(obj) is list) and all(

--- a/rdfproxy/utils/mapper_utils.py
+++ b/rdfproxy/utils/mapper_utils.py
@@ -26,6 +26,12 @@ def _is_list_basemodel_type(obj: type | None) -> bool:
     )
 
 
+def _is_model_or_list_model_type(obj: type | None) -> bool:
+    if obj is None:
+        return False
+    return _is_list_basemodel_type(obj) or issubclass(obj, BaseModel)
+
+
 def default_model_bool_predicate(model: BaseModel) -> bool:
     """Default predicate for determining model truthiness.
 

--- a/rdfproxy/utils/mapper_utils.py
+++ b/rdfproxy/utils/mapper_utils.py
@@ -15,8 +15,16 @@ def _is_list_type(obj: type | None) -> bool:
     return _is_type(obj, list)
 
 
-def _is_scalar_type(t) -> bool:
-    return (not _is_list_type(t)) and (not issubclass(t, BaseModel))
+def _is_scalar_type(obj) -> bool:
+    """Todo: this is clearly buggy. fix for actual implemenation."""
+    if obj is None:
+        return True
+    elif _is_list_type(obj):
+        return False
+    elif args := get_args(obj):
+        return all(_is_scalar_type(o) for o in args)
+    else:
+        return not issubclass(obj, BaseModel)
 
 
 def _is_list_basemodel_type(obj: type | None) -> bool:

--- a/rdfproxy/utils/models.py
+++ b/rdfproxy/utils/models.py
@@ -1,12 +1,12 @@
 """Pydantic Model definitions for rdfproxy."""
 
-from enum import StrEnum, auto
+from enum import StrEnum
 from typing import Any, Generic
 
 from pydantic import BaseModel, Field, model_validator
 from pydantic.fields import FieldInfo
 from rdfproxy.utils._types import _TModelInstance
-from rdfproxy.utils.mapper_utils import _is_scalar_type
+from rdfproxy.utils.utils import NamespacedFieldBindingsMap
 
 
 class Page(BaseModel, Generic[_TModelInstance]):
@@ -52,11 +52,7 @@ class QueryParameters(
         return data
 
     def __class_getitem__(cls, model: type[_TModelInstance]):
-        _order_by_fields = [
-            (k, auto())
-            for k, v in model.model_fields.items()
-            if _is_scalar_type(v.annotation)
-        ]
+        _order_by_fields = [(k, k) for k in NamespacedFieldBindingsMap(model).keys()]
 
         OrderByEnum = StrEnum("OrderByEnum", _order_by_fields)
         cls.model_fields["order_by"] = FieldInfo(annotation=OrderByEnum, default=None)

--- a/rdfproxy/utils/models.py
+++ b/rdfproxy/utils/models.py
@@ -6,6 +6,7 @@ from typing import Any, Generic
 from pydantic import BaseModel, Field, model_validator
 from pydantic.fields import FieldInfo
 from rdfproxy.utils._types import _TModelInstance
+from rdfproxy.utils.mapper_utils import _is_scalar_type
 
 
 class Page(BaseModel, Generic[_TModelInstance]):
@@ -54,7 +55,7 @@ class QueryParameters(
         _order_by_fields = [
             (k, auto())
             for k, v in model.model_fields.items()
-            if get_origin(v.annotation) is not list
+            if _is_scalar_type(v.annotation)
         ]
 
         OrderByEnum = StrEnum("OrderByEnum", _order_by_fields)

--- a/rdfproxy/utils/sparql_utils.py
+++ b/rdfproxy/utils/sparql_utils.py
@@ -64,7 +64,7 @@ def add_solution_modifier(
     modifiers = []
 
     if order_by is not None:
-        modifiers.append(f"order by ?{order_by}")
+        modifiers.append(f"order by {order_by}")
     if limit is not None:
         modifiers.append(f"limit {limit}")
     if offset is not None:

--- a/tests/unit/tests_sparql_utils/test_add_solution_modifier.py
+++ b/tests/unit/tests_sparql_utils/test_add_solution_modifier.py
@@ -29,12 +29,12 @@ parameters = [
     ),
     AddSolutionModifierParameter(
         query="prefix ns: <https://some.namespace> select * where {?s ?p ?o }",
-        parameters={"order_by": "x", "limit": None, "offset": None},
+        parameters={"order_by": "?x", "limit": None, "offset": None},
         expected="prefix ns: <https://some.namespace> select * where {?s ?p ?o } order by ?x",
     ),
     AddSolutionModifierParameter(
         query="prefix ns: <https://some.namespace> select * where {?s ?p ?o }",
-        parameters={"order_by": "x", "limit": 1, "offset": 1},
+        parameters={"order_by": "?x", "limit": 1, "offset": 1},
         expected="prefix ns: <https://some.namespace> select * where {?s ?p ?o } order by ?x limit 1 offset 1",
     ),
     # order
@@ -50,17 +50,17 @@ parameters = [
     ),
     AddSolutionModifierParameter(
         query="prefix ns: <https://some.namespace> select * where {?s ?p ?o }",
-        parameters={"offset": 1, "limit": None, "order_by": "x"},
+        parameters={"offset": 1, "limit": None, "order_by": "?x"},
         expected="prefix ns: <https://some.namespace> select * where {?s ?p ?o } order by ?x offset 1",
     ),
     AddSolutionModifierParameter(
         query="prefix ns: <https://some.namespace> select * where {?s ?p ?o }",
-        parameters={"offset": None, "limit": 1, "order_by": "x"},
+        parameters={"offset": None, "limit": 1, "order_by": "?x"},
         expected="prefix ns: <https://some.namespace> select * where {?s ?p ?o } order by ?x limit 1",
     ),
     AddSolutionModifierParameter(
         query="prefix ns: <https://some.namespace> select * where {?s ?p ?o }",
-        parameters={"offset": 1, "limit": 1, "order_by": "x"},
+        parameters={"offset": 1, "limit": 1, "order_by": "?x"},
         expected="prefix ns: <https://some.namespace> select * where {?s ?p ?o } order by ?x limit 1 offset 1",
     ),
 ]


### PR DESCRIPTION
Concerns #171.

This draft implements a prototype for field-based result ordering.

`QueryParameters` now implements a metaclass-ish hook for dynamically assigning an `Enum` of order-able model fields at model class parametrization time. This leads to improved OpenAPI docs, see my initial [metaclass draft](https://gist.github.com/lu-pl/718ebf86f5b81f68f2f88005c3663be6). Note that this is done with `__class_getitem__` now, which basically wraps metaclass behavior.

Also see the updated examples.
