### PR TITLE
fix: adapt types in full_static_model_fastapi_example.py

### DIFF
--- a/examples/full_static_fastapi_example.py
+++ b/examples/full_static_fastapi_example.py
@@ -18,9 +18,9 @@ select *
 where {
     values (?gnd ?authorName ?educatedAt ?workName ?work ?viaf) {
         (119359464 'Schindel' UNDEF 'Gebürtig' <http://www.wikidata.org/entity/Q1497409> UNDEF)
-        (115612815 'Geiger' 'University of Vienna' 'Der alte König in seinem Exil' <http://www.wikidata.org/entity/Q15805238> 299260555)
-        (115612815 'Geiger' 'University of Vienna' 'Der alte König in seinem Exil' <http://www.wikidata.org/entity/Q15805238> 6762154387354230970008)
-        (115612815 'Geiger' 'University of Vienna' 'Unter der Drachenwand' <http://www.wikidata.org/entity/Q58038819> 2277151717053313900002)
+        (115612815 'Geiger' 'University of Vienna' 'Der alte König in seinem Exil' <http://www.wikidata.org/entity/Q15805238> '299260555')
+        (115612815 'Geiger' 'University of Vienna' 'Der alte König in seinem Exil' <http://www.wikidata.org/entity/Q15805238> '6762154387354230970008')
+        (115612815 'Geiger' 'University of Vienna' 'Unter der Drachenwand' <http://www.wikidata.org/entity/Q58038819> '2277151717053313900002')
         (1136992030 'Edelbauer' 'University of Vienna' 'Das flüssige Land' <http://www.wikidata.org/entity/Q100266054> UNDEF)
         (1136992030 'Edelbauer' 'University of Applied Arts Vienna' 'Das flüssige Land' <http://www.wikidata.org/entity/Q100266054> UNDEF)
     }
@@ -38,7 +38,7 @@ class Work(BaseModel):
 class Author(BaseModel):
     model_config = ConfigDict(group_by="surname")
 
-    gnd: str
+    gnd: int
     surname: Annotated[str, SPARQLBinding("authorName")]
     works: list[Work]
     education: Annotated[list[str], SPARQLBinding("educatedAt")]


### PR DESCRIPTION
Bindings derived from SPARQL JSON responses feature type-casting according to rdflib.Literal.toPython now; this means that model field definitions must reflect this enhanced typing.

The change specifies more exact types in the
full_static_model_fastapi_example models which currently rightfully raise pydantic ValidationErrors.