### PR TITLE
fix: change Page.items type annotation to list[_ModelInstance]

### DIFF
--- a/rdfproxy/utils/models.py
+++ b/rdfproxy/utils/models.py
@@ -18,7 +18,7 @@ class Page(BaseModel, Generic[_TModelInstance]):
     for Generic Pydantic models.
     """
 
-    items: list[_TModelInstance] | dict[str, list[_TModelInstance]]
+    items: list[_TModelInstance]
     page: int
     size: int
     total: int


### PR DESCRIPTION
Page.items should not be annotated with a union type, RDFProxy will only ever assign list[_TModelInstance] to Page.item, which is also the intended type for that slot.

Closes #294.