### PR TITLE
fix: remove warnings filters and add stacklevel=2

### DIFF
--- a/rdfproxy/adapter.py
+++ b/rdfproxy/adapter.py
@@ -17,7 +17,6 @@ from rdfproxy.utils.models import Page, QueryParameters
 
 
 logger = logging.getLogger(__name__)
-warnings.simplefilter("always")
 
 
 class SPARQLModelAdapter(Generic[_TModelInstance]):
@@ -129,5 +128,6 @@ class SPARQLModelAdapter(Generic[_TModelInstance]):
             "SPARQLModelAdapter.query is deprecated. "
             "Use SPARQLModelAdapter.get_page instead.",
             PendingDeprecationWarning,
+            stacklevel=2,
         )
         return self.get_page(query_parameters=query_parameters)

--- a/rdfproxy/utils/checkers/_model_checks.py
+++ b/rdfproxy/utils/checkers/_model_checks.py
@@ -14,9 +14,6 @@ from rdfproxy.utils.type_utils import (
 )
 
 
-warnings.simplefilter("always")
-
-
 def _check_group_by_config(model: type[_TModelInstance]) -> type[_TModelInstance]:
     """Model check for group_by config settings and grouping model semantics."""
 
@@ -115,7 +112,7 @@ def _check_model_bool_config_root_model(
             "only for aggregated submodels and model union fields."
         )
 
-        warnings.warn(message=message)
+        warnings.warn(message=message, stacklevel=2)
 
     return model
 


### PR DESCRIPTION
Filters for warnings are meant to be controlled by client code and should not be defined in a library.

Also, stacklevel=2 should be set for warnings.warn so that *calling* code gets referenced in warnings, not *called* code.

A better solution for this would be skip_file_prefixes available with 3.12; see https://docs.python.org/3/library/warnings.html#warnings.warn.

Closes #293 .