### PR TITLE
feat: support httpx.AsyncClient configuration

### DIFF
--- a/rdfproxy/__init__.py
+++ b/rdfproxy/__init__.py
@@ -2,4 +2,4 @@ from rdfproxy.adapter import SPARQLModelAdapter  # noqa: F401
 from rdfproxy.mapper import ModelBindingsMapper  # noqa: F401
 from rdfproxy.sparqlwrapper import SPARQLWrapper  # noqa: F401
 from rdfproxy.utils._types import ConfigDict, SPARQLBinding  # noqa: F401
-from rdfproxy.utils.models import Page, QueryParameters  # noqa: F401
+from rdfproxy.utils.models import Page, QueryParameters, SPARQLWrapperConfig  # noqa: F401

--- a/rdfproxy/adapter.py
+++ b/rdfproxy/adapter.py
@@ -6,6 +6,7 @@ from typing import Generic
 import warnings
 
 from rdflib import Graph
+
 from rdfproxy.constructor import _ItemQueryConstructor, _PageQueryConstructor
 from rdfproxy.mapper import _ModelBindingsMapper
 from rdfproxy.sparqlwrapper import SPARQLWrapper
@@ -13,7 +14,7 @@ from rdfproxy.utils._types import _TModelInstance
 from rdfproxy.utils.checkers.item_checker import check_item_model, check_key
 from rdfproxy.utils.checkers.model_checker import check_model
 from rdfproxy.utils.checkers.query_checker import check_query
-from rdfproxy.utils.models import Page, QueryParameters
+from rdfproxy.utils.models import Page, QueryParameters, SPARQLWrapperConfig
 
 
 logger = logging.getLogger(__name__)
@@ -41,12 +42,20 @@ class SPARQLModelAdapter(Generic[_TModelInstance]):
         target: str | Graph,
         query: str,
         model: type[_TModelInstance],
+        sparqlwrapper_config: SPARQLWrapperConfig | None = None,
     ) -> None:
         self._target = target
         self._query = check_query(query)
         self._model = check_model(model)
 
-        self.sparqlwrapper = SPARQLWrapper(self._target)
+        sparqlwrapper_config = (
+            SPARQLWrapperConfig()
+            if sparqlwrapper_config is None
+            else sparqlwrapper_config
+        )
+        self.sparqlwrapper = SPARQLWrapper(
+            target=self._target, config=sparqlwrapper_config
+        )
 
         logger.info("Initialized SPARQLModelAdapter.")
         logger.debug("Target: %s", self._target)

--- a/rdfproxy/sparqlwrapper.py
+++ b/rdfproxy/sparqlwrapper.py
@@ -6,15 +6,20 @@ from typing import Any
 import httpx
 from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.query import Result as SPARQLQueryResult
+
 from rdfproxy.utils._types import _TSPARQLBindingValue
+from rdfproxy.utils.models import SPARQLWrapperConfig
 from rdfproxy.utils.utils import compose_left
 
 
 class SPARQLWrapper:
     """Simple httpx-based SPARQLWrapper implementaton for RDFProxy."""
 
-    def __init__(self, target: str | Graph):
+    def __init__(self, target: str | Graph, config: SPARQLWrapperConfig | None = None):
         self.target = target
+        self.config: SPARQLWrapperConfig = (
+            SPARQLWrapperConfig() if config is None else config
+        )
 
     def queries(self, *queries: str) -> list[Iterator[dict[str, _TSPARQLBindingValue]]]:
         """Synchronous wrapper for asynchronous SPARQL query execution.
@@ -37,7 +42,14 @@ class SPARQLWrapper:
         """Coroutine for running multiple queries against a remote target."""
         assert isinstance(self.target, str)  # type narrow
 
-        async with httpx.AsyncClient() as aclient, asyncio.TaskGroup() as tg:
+        aclient_config: dict = (
+            {} if (config := self.config.aclient_config) is None else config
+        )
+
+        async with (
+            httpx.AsyncClient(**aclient_config) as aclient,
+            asyncio.TaskGroup() as tg,
+        ):
             tasks = [
                 tg.create_task(
                     aclient.post(

--- a/rdfproxy/utils/models.py
+++ b/rdfproxy/utils/models.py
@@ -3,7 +3,13 @@
 from enum import StrEnum
 from typing import Any, Generic
 
-from pydantic import BaseModel, Field, create_model, model_validator
+
+from pydantic import (
+    BaseModel,
+    Field,
+    create_model,
+    model_validator,
+)
 from rdfproxy.utils._types import _TModelInstance
 from rdfproxy.utils.utils import ModelSPARQLMap
 
@@ -65,3 +71,9 @@ class QueryParameters(BaseModel):
         return create_model(
             cls.__name__, order_by=(OrderByEnum | None, None), __base__=cls
         )
+
+
+class SPARQLWrapperConfig(BaseModel):
+    """SPARQLWrapper configuration model."""
+
+    aclient_config: dict | None = None


### PR DESCRIPTION

The change introduces a basic `SPARQLWrapperConfig` model and a respective `sparqlwrapper_config: SPARQLWrapperConfig` parameter in `SPARQLModelAdapter` that allows to pass kwargs to the `httpx.AsyncClient` instances used by `rdfproxy.SPARQLWrapper`.

Note that `SPARQLWrapperConfig` anticipates the API for an upcoming more general configuration model for configuring a `sparqlx.SPARQLWrapper` instance.

The full `SPARQLWrapperConfig` model could look something like

```python
class SPARQLWrapperConfig(BaseModel):
    model_config = PydanticConfigDict(arbitrary_types_allowed=True)

    aclient: httpx.AsyncClient | None = None
    aclient_config: dict | None = None
    query_method: TLiteral["GET", "POST", "POST-direct"] = "POST"
```