### PR TITLE
chore: add dev shell entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 # Edit at https://www.toptal.com/developers/gitignore?templates=python
 \#*
 
+.envrc
+.direnv
+flake.nix
+flake.lock
+
 *scratch.py
 notes.org
 


### PR DESCRIPTION
The change adds entries for a dev shell flake, .envrc and .direnv to .gitignore. The current flake has to make pandas and numpy work by adding dynamic linking to system binaries. This kludge will be removed with the switch from Pandas to Polars - a proper dev shell flake shall then be publised.